### PR TITLE
fix: made code blocks scrollable if they overflow parent

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,7 @@
+.slidev-layout {
+  display: flex;
+  flex-direction: column;
+}
+.slidev-code-wrapper {
+  overflow-y: auto;
+}


### PR DESCRIPTION
Closes https://github.com/nearform/react-patterns-workshop/issues/355.

Made code blocks scrollable if they overflow parent.