### PR TITLE
fix(slides): add copyright and use current year

### DIFF
--- a/components/Copyright.js
+++ b/components/Copyright.js
@@ -1,0 +1,4 @@
+const Copyright = () =>
+    `© Copyright ${new Date().getFullYear()} Nearform Ltd. All Rights Reserved.`
+  
+  export default Copyright

--- a/slides.md
+++ b/slides.md
@@ -13,7 +13,7 @@ lineNumbers: false
 
 <div class="copyright">
 
-© Copyright 2022 NearForm Ltd. All Rights Reserved.
+<Copyright />
 
 </div>
 
@@ -560,7 +560,7 @@ Complete a custom Hook to query the most popular action movies of the current ye
 
 - Open the network tab of chrome dev tools (or equivalent in your browser of choice)
 - Refresh the page
-- Notice that the `movies?year=2022` is no longer called
+- Notice that the <code>movies?year={{ new Date().getFullYear() }}</code> is no longer called
 - The endpoint will only be called if you change the year in the filters
 
 </div>


### PR DESCRIPTION
fixes https://github.com/nearform/react-patterns-workshop/issues/568

updates slides to use same [copyright component](https://github.com/nearform/the-graphql-workshop/blob/master/components/Copyright.js) as graph-ql workshop

updates date in url example (step 10) to use current year. 